### PR TITLE
Add selection box for content selectors next to keyword field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1216,6 +1216,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
 - We fixed an issue when importing resulted in an exception [#7343](https://github.com/JabRef/jabref/issues/7343)
 - We fixed an issue where the field in the Field formatter dropdown selection were sorted in random order. [#7710](https://github.com/JabRef/jabref/issues/7710)
+- We added a selection box next to the keywords field, The list is filled with the contents of the content selectors, excluding existing keywords. [#10560](https://github.com/JabRef/jabref/issues/10560)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -96,7 +96,7 @@ public class FieldEditors {
         } else if (fieldProperties.contains(FieldProperty.PERSON_NAMES)) {
             return new PersonsEditor(field, suggestionProvider, preferences, fieldCheckers, isMultiLine, undoManager);
         } else if (StandardField.KEYWORDS == field) {
-            return new KeywordsEditor(field, suggestionProvider, fieldCheckers, preferences, undoManager);
+            return new KeywordsEditor(field, suggestionProvider, fieldCheckers, preferences, undoManager, databaseContext);
         } else if (field == InternalField.KEY_FIELD) {
             return new CitationKeyEditor(field, suggestionProvider, fieldCheckers, databaseContext);
         } else {

--- a/src/main/java/org/jabref/gui/fieldeditors/KeywordsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/KeywordsEditor.java
@@ -2,23 +2,39 @@ package org.jabref.gui.fieldeditors;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.scene.control.ComboBox;
+
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.logic.integrity.FieldCheckers;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.preferences.PreferencesService;
 
 public class KeywordsEditor extends SimpleEditor implements FieldEditorFX {
 
+    private final BibDatabaseContext databaseContext;
+    private ComboBox<String> keywordsComboBox;
     public KeywordsEditor(Field field,
                           SuggestionProvider<?> suggestionProvider,
                           FieldCheckers fieldCheckers,
                           PreferencesService preferences,
-                          UndoManager undoManager) {
+                          UndoManager undoManager,
+                          BibDatabaseContext databaseContext) {
         super(field, suggestionProvider, fieldCheckers, preferences, undoManager);
+        this.databaseContext = databaseContext;
+        this.keywordsComboBox = createKeywordsComboBox();
+        this.getChildren().add(keywordsComboBox);
     }
 
     @Override
     public double getWeight() {
         return 2;
+    }
+
+    private ComboBox<String> createKeywordsComboBox() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.getItems().addAll(databaseContext.getMetaData().getContentSelectorValuesForField(StandardField.KEYWORDS));
+        return comboBox;
     }
 }

--- a/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorView.java
@@ -83,6 +83,7 @@ public class ContentSelectorView extends AbstractPropertiesTabView<ContentSelect
     @FXML
     private void addNewKeyword() {
         getSelectedField().ifPresent(viewModel::showInputKeywordDialog);
+
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
@@ -175,6 +175,7 @@ public class ContentSelectorViewModel implements PropertiesTabViewModel {
                      .ifPresent(newKeyword -> addKeywordIfUnique(selectedField, newKeyword));
     }
 
+
     private void addKeywordIfUnique(Field field, String keywordToAdd) {
         boolean exists = fieldKeywordsMap.get(field).contains(keywordToAdd);
         if (exists) {


### PR DESCRIPTION
Implemented task 3 from https://github.com/JabRef/jabref/issues/10560.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
